### PR TITLE
Migracion a backend SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+backend/database.sqlite
+uploads/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Janvier Shop
+
+Este proyecto contiene una pequeña tienda web. Ahora incluye un backend en Node.js con SQLite para almacenar los productos y permitir varias imágenes por cada uno.
+
+## Requisitos
+- Node.js 18 o superior
+- npm
+- SQLite3
+
+## Instalación
+1. Situarse en la carpeta `backend` e instalar las dependencias:
+   ```bash
+   cd backend
+   npm install
+   ```
+2. Ejecutar la migración de los datos existentes desde `data/productos.json`:
+   ```bash
+   npm run migrate
+   ```
+3. Iniciar el servidor:
+   ```bash
+   npm start
+   ```
+   El servidor quedará disponible en `http://localhost:3000`.
+
+Los archivos subidos se guardan en la carpeta `uploads/`.
+
+## Uso en el Frontend
+Los scripts `admin.js` y `catalogo.js` consumen la API en `http://localhost:3000/api/productos` para listar, crear, actualizar y eliminar productos. En el formulario de administración se pueden proporcionar varias URLs de imagen separadas por coma.
+
+## Endpoints principales
+- `GET /api/productos` – Lista de productos con sus imágenes.
+- `POST /api/productos` – Crear producto.
+- `PUT /api/productos/:id` – Actualizar producto.
+- `DELETE /api/productos/:id` – Eliminar producto.
+- `POST /api/productos/:id/images` – Subir imágenes (multipart/form-data, campo `imagenes`).
+

--- a/admin.html
+++ b/admin.html
@@ -39,7 +39,7 @@
                 <label for="departamento">Departamento:</label>
                 <input type="text" id="departamento" required>
 
-                <label for="imagen">URL de Imagen:</label>
+                <label for="imagen">URLs de Imagen (separadas por coma):</label>
                 <input type="text" id="imagen" required>
 
                 <button type="submit" class="btn guardar-btn">Guardar Producto</button>

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,0 +1,99 @@
+const express = require('express');
+const path = require('path');
+const multer = require('multer');
+const db = require('./db');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use('/uploads', express.static(path.join(__dirname, '..', 'uploads')));
+
+// Configuracion de Multer para subir imagenes
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, path.join(__dirname, '..', 'uploads'));
+  },
+  filename: (req, file, cb) => {
+    const uniqueName = Date.now() + '-' + file.originalname;
+    cb(null, uniqueName);
+  }
+});
+const upload = multer({ storage });
+
+// Obtener todos los productos con sus imagenes
+app.get('/api/productos', (req, res) => {
+  const query = `SELECT p.*, GROUP_CONCAT(i.image_url) AS images
+                 FROM products p
+                 LEFT JOIN product_images i ON p.id = i.product_id
+                 GROUP BY p.id`;
+  db.all(query, [], (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    const productos = rows.map(r => ({
+      id: r.id,
+      marca: r.marca,
+      modelo: r.modelo,
+      codigo: r.codigo,
+      precioCompra: r.precio_compra,
+      precioVenta: r.precio_venta,
+      descripcion: r.descripcion,
+      clasificacion: r.clasificacion,
+      departamento: r.departamento,
+      imagenes: r.images ? r.images.split(',') : []
+    }));
+    res.json({ productos });
+  });
+});
+
+// Crear un nuevo producto
+app.post('/api/productos', (req, res) => {
+  const { marca, modelo, codigo, precioCompra, precioVenta, descripcion, clasificacion, departamento, imagenes = [] } = req.body;
+  const sql = `INSERT INTO products (marca, modelo, codigo, precio_compra, precio_venta, descripcion, clasificacion, departamento)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)`;
+  db.run(sql, [marca, modelo, codigo, precioCompra, precioVenta, descripcion, clasificacion, departamento], function(err) {
+    if (err) return res.status(500).json({ error: err.message });
+    const productId = this.lastID;
+    const stmt = db.prepare('INSERT INTO product_images (product_id, image_url) VALUES (?, ?)');
+    imagenes.forEach(img => stmt.run(productId, img));
+    stmt.finalize();
+    res.json({ id: productId });
+  });
+});
+
+// Actualizar producto
+app.put('/api/productos/:id', (req, res) => {
+  const { marca, modelo, codigo, precioCompra, precioVenta, descripcion, clasificacion, departamento, imagenes = [] } = req.body;
+  const sql = `UPDATE products SET marca=?, modelo=?, codigo=?, precio_compra=?, precio_venta=?, descripcion=?, clasificacion=?, departamento=? WHERE id=?`;
+  db.run(sql, [marca, modelo, codigo, precioCompra, precioVenta, descripcion, clasificacion, departamento, req.params.id], function(err) {
+    if (err) return res.status(500).json({ error: err.message });
+    db.run('DELETE FROM product_images WHERE product_id=?', [req.params.id], err2 => {
+      if (err2) return res.status(500).json({ error: err2.message });
+      const stmt = db.prepare('INSERT INTO product_images (product_id, image_url) VALUES (?, ?)');
+      imagenes.forEach(img => stmt.run(req.params.id, img));
+      stmt.finalize();
+      res.json({ updated: true });
+    });
+  });
+});
+
+// Eliminar producto
+app.delete('/api/productos/:id', (req, res) => {
+  db.run('DELETE FROM products WHERE id=?', [req.params.id], err => {
+    if (err) return res.status(500).json({ error: err.message });
+    db.run('DELETE FROM product_images WHERE product_id=?', [req.params.id]);
+    res.json({ deleted: true });
+  });
+});
+
+// Subir nuevas imagenes
+app.post('/api/productos/:id/images', upload.array('imagenes'), (req, res) => {
+  const productId = req.params.id;
+  const stmt = db.prepare('INSERT INTO product_images (product_id, image_url) VALUES (?, ?)');
+  req.files.forEach(f => stmt.run(productId, '/uploads/' + f.filename));
+  stmt.finalize();
+  res.json({ uploaded: req.files.length });
+});
+
+app.listen(PORT, () => {
+  console.log(`Servidor iniciado en http://localhost:${PORT}`);
+});

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,28 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+const dbFile = path.join(__dirname, 'database.sqlite');
+
+const db = new sqlite3.Database(dbFile);
+
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS products (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    marca TEXT,
+    modelo TEXT,
+    codigo TEXT,
+    precio_compra REAL,
+    precio_venta REAL,
+    descripcion TEXT,
+    clasificacion TEXT,
+    departamento TEXT
+  )`);
+
+  db.run(`CREATE TABLE IF NOT EXISTS product_images (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    product_id INTEGER,
+    image_url TEXT,
+    FOREIGN KEY(product_id) REFERENCES products(id)
+  )`);
+});
+
+module.exports = db;

--- a/backend/migrate.js
+++ b/backend/migrate.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const db = require('./db');
+
+const jsonPath = path.join(__dirname, '..', 'data', 'productos.json');
+const raw = fs.readFileSync(jsonPath, 'utf8');
+const data = JSON.parse(raw);
+
+function insertarProducto(prod) {
+  return new Promise((resolve, reject) => {
+    const { marca, modelo, codigo, precioCompra, precioVenta, descripcion, clasificacion, departamento, imagen } = prod;
+    const sql = `INSERT INTO products (marca, modelo, codigo, precio_compra, precio_venta, descripcion, clasificacion, departamento)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`;
+    db.run(sql, [marca, modelo, codigo, precioCompra, precioVenta, descripcion, clasificacion, departamento], function(err) {
+      if (err) return reject(err);
+      const id = this.lastID;
+      const imagenes = prod.imagenes || (imagen ? [imagen] : []);
+      const stmt = db.prepare('INSERT INTO product_images (product_id, image_url) VALUES (?, ?)');
+      imagenes.forEach(img => stmt.run(id, img));
+      stmt.finalize();
+      resolve();
+    });
+  });
+}
+
+(async () => {
+  for (const p of data.productos) {
+    try {
+      await insertarProducto(p);
+    } catch (e) {
+      console.error('Error insertando', p, e);
+    }
+  }
+  console.log('Migracion completada');
+  db.close();
+})();

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "janvier_shop_backend",
+  "version": "1.0.0",
+  "description": "Backend API para Janvier Shop",
+  "main": "app.js",
+  "scripts": {
+    "start": "node app.js",
+    "migrate": "node migrate.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.6",
+    "multer": "^1.4.5"
+  }
+}

--- a/scripts/catalogo.js
+++ b/scripts/catalogo.js
@@ -1,8 +1,9 @@
 const catalogoContainer = document.getElementById('catalogo-container');
 let productos = [];
+const API_URL = '/api/productos';
 
-// Cargar los productos desde el JSON
-fetch('data/productos.json')
+// Cargar los productos desde la API
+fetch(API_URL)
     .then(response => response.json())
     .then(data => {
         productos = data.productos; // Guardar los productos en una variable global
@@ -17,8 +18,9 @@ function mostrarProductos(productos) {
     productos.forEach(producto => {
         const divProducto = document.createElement('div');
         divProducto.classList.add('producto');
+        const imgSrc = (producto.imagenes && producto.imagenes[0]) || producto.imagen || '';
         divProducto.innerHTML = `
-            <img src="${producto.imagen}" alt="${producto.modelo}" class="producto-imagen">
+            <img src="${imgSrc}" alt="${producto.modelo}" class="producto-imagen">
             <h3>${producto.marca} ${producto.modelo}</h3>
             <p>${producto.descripcion}</p>
             <p class="precio">$${producto.precioVenta.toLocaleString()}</p>


### PR DESCRIPTION
## Resumen
- agregar servidor Express con SQLite para CRUD de productos
- script de migración desde `data/productos.json`
- actualizar scripts de frontend para consumir la nueva API y soportar varias imágenes
- modificar formulario de admin para ingresar varias URLs
- documentación básica en `README.md`
- añadir `.gitignore`

## Testing
- `node backend/migrate.js` *(falló: Cannot find module 'sqlite3')*

------
https://chatgpt.com/codex/tasks/task_e_68485ce1cebc832199f8f417fe458872